### PR TITLE
feat: implement guest mode with 3-message limit for AI chat

### DIFF
--- a/components/custom-connect-button.tsx
+++ b/components/custom-connect-button.tsx
@@ -205,6 +205,7 @@ export function CustomConnectButton() {
         }}
         variant="outline"
         className="gap-2 border-primary/50 hover:bg-primary/10 hover:border-primary transition-all duration-300"
+        data-wallet-connect
       >
         <Wallet className="w-4 h-4" />
         Connect Wallet

--- a/hooks/useGuestMode.ts
+++ b/hooks/useGuestMode.ts
@@ -1,0 +1,138 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+
+const GUEST_MESSAGE_LIMIT = 3
+const STORAGE_KEY = 'guest_mode_data'
+const RESET_INTERVAL = 24 * 60 * 60 * 1000 // 24 hours in milliseconds
+
+interface GuestModeData {
+  messageCount: number
+  lastResetDate: string
+  chatMode?: 'token' | 'vesting' | 'general'
+}
+
+interface UseGuestModeReturn {
+  messageCount: number
+  remainingMessages: number
+  isLimitReached: boolean
+  canSendMessage: boolean
+  incrementMessageCount: () => void
+  resetMessageCount: () => void
+  getCounterText: () => string
+  shouldShowCounter: boolean
+}
+
+export function useGuestMode(chatMode?: 'token' | 'vesting' | 'general'): UseGuestModeReturn {
+  const { isAuthenticated } = useAuth()
+  const [messageCount, setMessageCount] = useState(0)
+  
+  // Load data from localStorage on mount
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    
+    try {
+      const storedData = localStorage.getItem(STORAGE_KEY)
+      if (storedData) {
+        const data: GuestModeData = JSON.parse(storedData)
+        
+        // Check if we need to reset based on time
+        const lastReset = new Date(data.lastResetDate)
+        const now = new Date()
+        const timeDiff = now.getTime() - lastReset.getTime()
+        
+        if (timeDiff >= RESET_INTERVAL) {
+          // Reset after 24 hours
+          resetMessageCount()
+        } else {
+          setMessageCount(data.messageCount)
+        }
+      } else {
+        // Initialize for first time users
+        resetMessageCount()
+      }
+    } catch (error) {
+      console.error('Error loading guest mode data:', error)
+      resetMessageCount()
+    }
+  }, [])
+  
+  // Save to localStorage whenever count changes
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    
+    try {
+      const data: GuestModeData = {
+        messageCount,
+        lastResetDate: new Date().toISOString(),
+        chatMode
+      }
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+    } catch (error) {
+      console.error('Error saving guest mode data:', error)
+    }
+  }, [messageCount, chatMode])
+  
+  // Reset count when user authenticates
+  useEffect(() => {
+    if (isAuthenticated) {
+      resetMessageCount()
+    }
+  }, [isAuthenticated])
+  
+  const incrementMessageCount = useCallback(() => {
+    if (!isAuthenticated && messageCount < GUEST_MESSAGE_LIMIT) {
+      setMessageCount(prev => Math.min(prev + 1, GUEST_MESSAGE_LIMIT))
+    }
+  }, [isAuthenticated, messageCount])
+  
+  const resetMessageCount = useCallback(() => {
+    setMessageCount(0)
+    if (typeof window !== 'undefined') {
+      try {
+        const data: GuestModeData = {
+          messageCount: 0,
+          lastResetDate: new Date().toISOString(),
+          chatMode
+        }
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+      } catch (error) {
+        console.error('Error resetting guest mode data:', error)
+      }
+    }
+  }, [chatMode])
+  
+  const getCounterText = useCallback(() => {
+    if (isAuthenticated) return ''
+    
+    const remaining = GUEST_MESSAGE_LIMIT - messageCount
+    if (remaining === 0) {
+      return 'Connect wallet to continue'
+    }
+    if (remaining === 1) {
+      return '1 message remaining'
+    }
+    return `${remaining}/${GUEST_MESSAGE_LIMIT} messages remaining`
+  }, [isAuthenticated, messageCount])
+  
+  // Computed values
+  const remainingMessages = isAuthenticated 
+    ? Infinity 
+    : Math.max(0, GUEST_MESSAGE_LIMIT - messageCount)
+  
+  const isLimitReached = !isAuthenticated && messageCount >= GUEST_MESSAGE_LIMIT
+  const canSendMessage = isAuthenticated || messageCount < GUEST_MESSAGE_LIMIT
+  const shouldShowCounter = !isAuthenticated && messageCount > 0
+  
+  return {
+    messageCount,
+    remainingMessages,
+    isLimitReached,
+    canSendMessage,
+    incrementMessageCount,
+    resetMessageCount,
+    getCounterText,
+    shouldShowCounter
+  }
+}


### PR DESCRIPTION
✨ Features:
- Add useGuestMode hook with localStorage persistence
- Implement 3-message limit for unauthenticated users
- Add message counter UI with progressive disclosure
- Create wallet connection prompt modal after limit reached
- Auto-reset counter on wallet connection and 24h expiry

🎨 UI/UX:
- Subtle counter badge in input field (2/3, 1/3)
- Warning indicators for last message
- Disabled input state when limit reached
- Smooth animations and transitions
- Elegant upgrade prompt modal

🔧 Technical:
- localStorage-based message tracking
- Integration with existing authentication system
- Support for different chat modes (token, vesting, general)
- Responsive design and accessibility

Closes #45